### PR TITLE
Adapter Fixes

### DIFF
--- a/empyric/__init__.py
+++ b/empyric/__init__.py
@@ -10,8 +10,6 @@ except ImportError:
 
 from empyric.experiment import Manager
 
-# TODO add logging.FileHandler to drop log into file in working directory
-
 # List of testable features.
 # Tests are invoked at the command line with `empyric --test <feature>`
 testable_features = [

--- a/empyric/__init__.py
+++ b/empyric/__init__.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
-import datetime
+
+from empyric.tools import logger
 
 try:
     import pytest
@@ -8,13 +9,6 @@ except ImportError:
     pytest = None
 
 from empyric.experiment import Manager
-
-# Set up logging
-logger = logging.getLogger("empyric")
-
-log_stream_handler = logging.StreamHandler()
-log_stream_handler.setLevel(logging.WARNING)
-logger.addHandler(log_stream_handler)
 
 # TODO add logging.FileHandler to drop log into file in working directory
 

--- a/empyric/__init__.py
+++ b/empyric/__init__.py
@@ -8,9 +8,9 @@ try:
 except ImportError:
     pytest = None
 
+from empyric.tools import logger, log_stream_handler
 from empyric.experiment import Manager
 
-from empyric.tools import logger, log_stream_handler
 
 # List of testable features.
 # Tests are invoked at the command line with `empyric --test <feature>`

--- a/empyric/adapters.py
+++ b/empyric/adapters.py
@@ -21,7 +21,6 @@ def chaperone(method):
     """
 
     def wrapped_method(self, *args, validator=None, **kwargs):
-
         self.lock.acquire()
 
         traceback = None
@@ -35,7 +34,6 @@ def chaperone(method):
                 try:
                     self.connect()
                 except Exception as exception:
-
                     traceback = exception.__traceback__
 
                     logger.error(
@@ -1383,7 +1381,6 @@ class Modbus(Adapter):
         return self._read(*args, **kwargs)
 
     def disconnect(self):
-
         while self.backend.connected:
             self.backend.close()
             time.sleep(self.delay)

--- a/empyric/adapters.py
+++ b/empyric/adapters.py
@@ -92,7 +92,7 @@ def chaperone(method):
                     traceback = exception.__traceback__
 
 
-                    logger.warning(
+                    logger.error(
                         f"Encountered '{exception}' while trying "
                         f"to talk to {self.instrument.name}"
                     )
@@ -1416,7 +1416,6 @@ class Modbus(Adapter):
     def disconnect(self):
         while self.backend.connected:
             self.backend.close()
-            time.sleep(self.delay)
 
         self.connected = False
 

--- a/empyric/adapters.py
+++ b/empyric/adapters.py
@@ -1180,6 +1180,10 @@ class Modbus(Adapter):
     def busy(self, busy):
         self._busy = busy
 
+    @property
+    def connected(self):
+        return self.backend.connected
+
     def connect(self):
         client = importlib.import_module(".client", package="pymodbus")
 
@@ -1192,9 +1196,9 @@ class Modbus(Adapter):
                 self.protocol = "UDP"
 
                 if len(address) == 1:
-                    address.append(
-                        502
-                    )  # standard Modbus UDP port (fascinating that it's the same as TCP)
+                    address.append(502)
+                    # standard Modbus UDP port (fascinating that it's the same as TCP)
+
                 self.backend = client.ModbusUdpClient(
                     host=address[0], port=int(address[1])
                 )
@@ -1251,9 +1255,6 @@ class Modbus(Adapter):
 
         # Utility for decoding data
         self._decoder_cls = payload_module.BinaryPayloadDecoder
-
-        if self.backend.connected:
-            self.connected = True
 
     def _write(self, func_code, address, values, _type="16bit_uint"):
         """
@@ -1414,11 +1415,9 @@ class Modbus(Adapter):
         return self._read(*args, **kwargs)
 
     def disconnect(self):
-        while self.backend.connected:
+        while self.connected:
             self.backend.close()
-            time.sleep(self.delay)
-
-        self.connected = False
+            time.sleep(0.1)
 
 
 class Phidget(Adapter):

--- a/empyric/adapters.py
+++ b/empyric/adapters.py
@@ -2,13 +2,12 @@ import importlib
 import socket
 import time
 import re
-from warnings import warn
+
 from threading import Lock
 
 import numpy as np
-from empyric import logger
 
-from empyric.tools import read_from_socket, write_to_socket
+from empyric.tools import logger, read_from_socket, write_to_socket
 
 
 def chaperone(method):

--- a/empyric/adapters.py
+++ b/empyric/adapters.py
@@ -1416,6 +1416,7 @@ class Modbus(Adapter):
     def disconnect(self):
         while self.backend.connected:
             self.backend.close()
+            time.sleep(self.delay)
 
         self.connected = False
 

--- a/empyric/collection/instrument.py
+++ b/empyric/collection/instrument.py
@@ -232,7 +232,7 @@ class Instrument:
         """
 
         self.address = address
-        
+
         if "connected" not in self.knobs:
             self.knobs = ("connected",) + self.knobs
 
@@ -426,7 +426,6 @@ class Instrument:
 
         if self.adapter.connected:
             for knob, value in self.postsets.items():
-
                 try:
                     self.set(knob, value)
                 except AdapterError as adapter_error:

--- a/empyric/collection/instrument.py
+++ b/empyric/collection/instrument.py
@@ -206,14 +206,6 @@ class Instrument:
 
     meters = tuple()
 
-    # This lock is used to prevent commands executed in separate threads from
-    # interfering with each other. The lock is acquired in the setter, getter
-    # and measurer wrapper functions and then released when the wrapped
-    # operation is complete. Using an RLock allows set, get and measure
-    # methods to call other such methods without blocking, as long as it
-    # happens in the same thread, which is the norm.
-    lock = RLock()
-
     raise_connection_error = True
 
     def __init__(
@@ -265,6 +257,14 @@ class Instrument:
 
         if self.address:
             self.name = self.name + "@" + str(self.address)
+
+        # This lock is used to prevent commands executed in separate threads from
+        # interfering with each other. The lock is acquired in the setter, getter
+        # and measurer wrapper functions and then released when the wrapped
+        # operation is complete. Using an RLock allows set, get and measure
+        # methods to call other such methods without blocking, as long as it
+        # happens in the same thread, which is the norm.
+        self.lock = RLock()
 
         # Get existing knob settings, if possible
         for knob in self.knobs:

--- a/empyric/collection/instrument.py
+++ b/empyric/collection/instrument.py
@@ -4,7 +4,7 @@ from functools import wraps
 
 from empyric.tools import logger
 from empyric.types import recast, Type, ON, OFF, Toggle
-from empyric.adapters import Adapter
+from empyric.adapters import Adapter, AdapterError
 
 
 def setter(method):
@@ -251,7 +251,7 @@ class Instrument:
 
     meters = tuple()
 
-    raise_connection_error = True
+    ignore_errors = False
 
     def __init__(
         self, address=None, adapter=None, presets=None, postsets=None, **kwargs
@@ -353,10 +353,10 @@ class Instrument:
         try:
             return self.adapter.write(*args, **kwargs)
         except AdapterError as adapter_error:
-            if self.raise_connection_error:
-                raise adapter_error
-            else:
+            if self.ignore_errors:
                 logger.error(str(adapter_error))
+            else:
+                raise adapter_error
 
     def read(self, *args, **kwargs):
         """
@@ -370,10 +370,10 @@ class Instrument:
         try:
             return self.adapter.read(*args, **kwargs)
         except AdapterError as adapter_error:
-            if self.raise_connection_error:
-                raise adapter_error
-            else:
+            if self.ignore_errors:
                 logger.error(str(adapter_error))
+            else:
+                raise adapter_error
 
     def query(self, *args, **kwargs):
         """
@@ -387,10 +387,10 @@ class Instrument:
         try:
             return self.adapter.query(*args, **kwargs)
         except AdapterError as adapter_error:
-            if self.raise_connection_error:
-                raise adapter_error
-            else:
+            if self.ignore_errors:
                 logger.error(str(adapter_error))
+            else:
+                raise adapter_error
 
     def set(self, knob: str, value):
         """
@@ -462,10 +462,10 @@ class Instrument:
                 **self.kwargs,
             )
         except ConnectionError as connection_error:
-            if self.raise_connection_error:
-                raise connection_error
-            else:
+            if self.ignore_errors:
                 logger.error(str(connection_error))
+            else:
+                raise connection_error
 
     def disconnect(self):
         """
@@ -479,18 +479,18 @@ class Instrument:
                 try:
                     self.set(knob, value)
                 except AdapterError as adapter_error:
-                    if self.raise_connection_error:
-                        raise adapter_error
-                    else:
+                    if self.ignore_errors:
                         logger.error(str(adapter_error))
+                    else:
+                        raise adapter_error
 
             try:
                 self.adapter.disconnect()
             except ConnectionError as connection_error:
-                if self.raise_connection_error:
-                    raise connection_error
-                else:
+                if self.ignore_errors:
                     logger.error(str(connection_error))
+                else:
+                    raise connection_error
 
         else:
             raise ConnectionError(f"adapter for {self.name} is not connected!")

--- a/empyric/experiment.py
+++ b/empyric/experiment.py
@@ -134,8 +134,8 @@ class Experiment:
 
         self.state = pd.Series(
             name=None,
-            data={**{'Time': None}, **{name: None for name in self.variables}},
-            dtype=object
+            data={**{"Time": None}, **{name: None for name in self.variables}},
+            dtype=object,
         )
         self.data = pd.DataFrame(columns=["Time"] + list(variables.keys()))
 
@@ -423,7 +423,6 @@ class AsyncExperiment(Experiment):
     async def _update_routine(self, name):
         """Update named routine"""
         if self.running:
-
             # Update time
             self.state["Time"] = self.clock.time
             self.state.name = datetime.datetime.now()
@@ -455,7 +454,9 @@ class AsyncExperiment(Experiment):
     def start(self):
         super().start()
 
-        self._updating_thread = threading.Thread(target=asyncio.run, args=(self._run_loop(),))
+        self._updating_thread = threading.Thread(
+            target=asyncio.run, args=(self._run_loop(),)
+        )
 
         self._updating_thread.start()
 

--- a/empyric/tests/henon_runcard_example.yaml
+++ b/empyric/tests/henon_runcard_example.yaml
@@ -14,6 +14,7 @@ Settings:
  plot interval: 5
  save interval: 10
  end: 60
+# async: True
 
 Instruments:
  Henon Mapper:
@@ -49,7 +50,9 @@ Variables:
 
 Alarms:
  r > 1:
-  condition: 'Distance r > 1'
+  condition: 'r > 1'
+  definitions:
+   r: Distance r
   protocol: hold
 
 Plots:

--- a/empyric/tools.py
+++ b/empyric/tools.py
@@ -12,6 +12,9 @@ log_stream_handler = logging.StreamHandler()
 log_stream_handler.setLevel(logging.WARNING)
 logger.addHandler(log_stream_handler)
 
+# TODO add logging.FileHandler to drop log into file in working directory
+
+
 # Tools for time-keeping
 def convert_time(time_value):
     """

--- a/empyric/tools.py
+++ b/empyric/tools.py
@@ -2,8 +2,15 @@ import time
 import select
 import socket
 import numbers
+import logging
 import numpy as np
 
+# Set up logging
+logger = logging.getLogger("empyric")
+
+log_stream_handler = logging.StreamHandler()
+log_stream_handler.setLevel(logging.WARNING)
+logger.addHandler(log_stream_handler)
 
 # Tools for time-keeping
 def convert_time(time_value):

--- a/empyric/variables.py
+++ b/empyric/variables.py
@@ -212,7 +212,6 @@ class Knob(Variable):
         """
 
         try:
-
             if self.upper_limit and value > self.upper_limit:
                 self.instrument.set(
                     self.knob, (self.upper_limit - self.offset) / self.multiplier
@@ -223,12 +222,13 @@ class Knob(Variable):
                 )
             else:
                 if isinstance(value, numbers.Number):
-                    self.instrument.set(self.knob, (value - self.offset) / self.multiplier)
+                    self.instrument.set(
+                        self.knob, (value - self.offset) / self.multiplier
+                    )
                 else:
                     self.instrument.set(self.knob, value)
 
         except TypeError as type_error:
-
             warnings.warn(str(type_error))
 
         self._value = self.instrument.__getattribute__(self.knob.replace(" ", "_"))


### PR DESCRIPTION
The following improvements have been made:

- `chaperone` now only throws an `AdapterError` at the end of all attempts and reconnects; otherwise the caught exceptions are logged.
- `Modbus.connected` property now refers to the `pymodbus.client.ModbusXYZClient`'s `connected` attribute, rather than just assuming that it connected or disconnected on completion of the corresponding method calls.
- Instruments now have a `raise_connection_error` attribute that determines whether an AdapterError raised by its adapter is raised or just logged. This might be advantageous in experiments with a large number of instruments, where you may not want a connection issue with one instrument taking down the whole process.