### PR TITLE
Custom Modbus Register Allocation

### DIFF
--- a/empyric/adapters.py
+++ b/empyric/adapters.py
@@ -1438,7 +1438,6 @@ class Modbus(Adapter):
     def disconnect(self):
         while self.connected:
             self.backend.close()
-            time.sleep(0.1)
 
 
 class Phidget(Adapter):

--- a/empyric/experiment.py
+++ b/empyric/experiment.py
@@ -940,7 +940,9 @@ def convert_runcard(runcard):
             # Get knobs
             knobs = specs.pop("knobs", None)
 
-            if isinstance(knobs, dict):  # shortcut for ModbusServer
+            if np.isscalar(knobs):
+                knobs = [knobs]
+            elif isinstance(knobs, dict):  # shortcut for ModbusServer
                 knob_addresses = np.array(list(knobs.keys())).flatten()
                 knobs = np.array(list(knobs.values())).flatten()
                 specs["knob_addresses"] = knob_addresses
@@ -967,7 +969,9 @@ def convert_runcard(runcard):
             # Get meters
             meters = specs.pop("meters", None)
 
-            if isinstance(meters, dict):  # shortcut for ModbusServer
+            if np.isscalar(meters):
+                meters = [meters]
+            elif isinstance(meters, dict):  # shortcut for ModbusServer
                 meter_addresses = np.array(list(meters.keys())).flatten()
                 meters = np.array(list(meters.values())).flatten()
 

--- a/empyric/experiment.py
+++ b/empyric/experiment.py
@@ -18,6 +18,7 @@ from typing import Union
 import numpy as np
 import pandas as pd
 import pykwalify.errors
+from pandas.core.computation import expressions
 from pykwalify.core import Core as YamlValidator
 from ruamel.yaml import YAML
 
@@ -936,9 +937,22 @@ def convert_runcard(runcard):
 
             specs = {key.replace(" ", "_"): value for key, value in specs.items()}
 
-            # Convert list of knobs into dictionary
-            knobs = np.array([specs.get("knobs", [])]).flatten()
-            if knobs.size > 0:
+            # Get knobs
+            knobs = specs.pop("knobs", None)
+
+            if isinstance(knobs, dict):  # shortcut for ModbusServer
+                knob_addresses = np.array(list(knobs.keys())).flatten()
+                knobs = np.array(list(knobs.values())).flatten()
+                specs["knob_addresses"] = knob_addresses
+            elif knobs is not None and not isinstance(knobs, list):
+                raise ValueError(
+                    f"Invalid knobs specification for routine {name}; "
+                    "Must be a list of knob names or optionally a dictionary "
+                    "of register addresses and knob names for a ModbusServer"
+                )
+
+            # Convert list of knobs into dictionary of {name: knob} pairs
+            if knobs is not None and len(knobs) > 0:
                 for knob in knobs:
                     if knob not in variables:
                         raise KeyError(
@@ -947,6 +961,25 @@ def convert_runcard(runcard):
                         )
 
                 specs["knobs"] = {name: variables[name] for name in knobs}
+            else:
+                specs["knobs"] = None
+
+            # Get meters
+            meters = specs.pop("meters", None)
+
+            if isinstance(meters, dict):  # shortcut for ModbusServer
+                meter_addresses = np.array(list(meters.keys())).flatten()
+                meters = np.array(list(meters.values())).flatten()
+
+                specs["meter_addresses"] = meter_addresses
+            elif meters is not None and not isinstance(meters, list):
+                raise ValueError(
+                    f"Invalid meters specification for routine {name}; "
+                    "Must be a list of meter names or optionally a dictionary "
+                    "of register addresses and meter names for a ModbusServer"
+                )
+
+            specs["meters"] = meters
 
             routines[name] = available_routines[_type](**specs)
 

--- a/empyric/graphics.py
+++ b/empyric/graphics.py
@@ -873,8 +873,11 @@ class ExperimentGUI:
         plt.pause(0.1)  # give GUI and plotter enough time to wrap up
         self.root.update()
 
-        self.root.destroy()
-        self.root.quit()
+        try:
+            self.root.destroy()
+            self.root.quit()
+        except tk.TclError:  # happens when window has already been closed
+            pass
 
     @staticmethod
     def _entry_enter(entry, variable, root):

--- a/empyric/routines.py
+++ b/empyric/routines.py
@@ -1286,7 +1286,7 @@ class ModbusServer(Routine):
             for i, (name, variable) in enumerate(self.knobs.items()):
                 value = variable._value
 
-                builder = builder(byteorder=">")
+                builder = self._payload_builder(byteorder=">")
 
                 # encode the value into the 4 registers
                 if value is None or variable._type is None:
@@ -1404,7 +1404,11 @@ class ModbusServer(Routine):
         self.state = state
 
     def terminate(self):
-        asyncio.run(self.server.shutdown())
+
+        try:
+            asyncio.create_task(self.server.shutdown())
+        except RuntimeError:  # happens if loop has already ended
+            pass
 
 
 supported = {

--- a/examples/Server Examples/modbus_client_example.yaml
+++ b/examples/Server Examples/modbus_client_example.yaml
@@ -21,7 +21,7 @@ Variables:
  Distance r: # This remote variable is not settable (expression on server)
   server: 127.0.0.1::6174
   protocol: modbus
-  alias: 200  # input register address for Knob a on modbus server
+  alias: 200  # input register address for Distance r on modbus server
 
 Plots:
  R Plot:

--- a/examples/Server Examples/modbus_client_example.yaml
+++ b/examples/Server Examples/modbus_client_example.yaml
@@ -14,14 +14,14 @@ Settings:
 
 Variables:
  Knob a: # This remote variable is settable (knob on server)
-  server: 192.168.86.206::502  # replace with the ip address and port of your server
+  server: 127.0.0.1::6174
   protocol: modbus
   settable: True
-  alias: 0  # replace with the register address of the remote variable
+  alias: 0  # holding register address for Knob a on modbus server
  Distance r: # This remote variable is not settable (expression on server)
-  server: 192.168.86.206::502  # replace with the ip address and port of your server
+  server: 127.0.0.1::6174
   protocol: modbus
-  alias: 20  # replace with the register address of the remote variable
+  alias: 20  # input register address for Knob a on modbus server
 
 Plots:
  R Plot:

--- a/examples/Server Examples/modbus_client_example.yaml
+++ b/examples/Server Examples/modbus_client_example.yaml
@@ -14,14 +14,14 @@ Settings:
 
 Variables:
  Knob a: # This remote variable is settable (knob on server)
-  server: 127.0.0.1::6174
+  server: 127.0.0.1::6174  # must match the IP address and port of the server
   protocol: modbus
-  settable: True
+  settable: True  # set to True to access knobs on the server, or False to read meters
   alias: 0  # holding register address for Knob a on modbus server
  Distance r: # This remote variable is not settable (expression on server)
   server: 127.0.0.1::6174
   protocol: modbus
-  alias: 20  # input register address for Knob a on modbus server
+  alias: 200  # input register address for Knob a on modbus server
 
 Plots:
  R Plot:

--- a/examples/Server Examples/modbus_server_example.yaml
+++ b/examples/Server Examples/modbus_server_example.yaml
@@ -79,6 +79,8 @@ Routines:
   values: [0.0, 0.3]
  Server:
   type: ModbusServer
+  address: 127.0.0.1
+  port: 6174
   knobs:
    - Knob a
    - Knob b

--- a/examples/Server Examples/modbus_server_example.yaml
+++ b/examples/Server Examples/modbus_server_example.yaml
@@ -79,8 +79,14 @@ Routines:
   values: [0.0, 0.3]
  Server:
   type: ModbusServer
-  address: 127.0.0.1
-  port: 6174
+  address: 127.0.0.1  # this is the default localhost IP address, but can be set to any IP address assigned by a network to the host computer (clients must be on the same network)
+  port: 6174  # the default port for modbus communication is 502, but any other valid port can be used
   knobs:
-   - Knob a
-   - Knob b
+  # variables can be specified by a list
+   - Knob a  # stored in registers 0 to 4
+   - Knob b  # stored in registers 5 to 9
+  meters:
+  # ... or by a dictionary that maps variables to specific starting registers
+   0: Coordinate x  # stored in registers 0 to 4
+   100: Coordinate y  # stored in registers 100 to 104
+   200: Distance r  # stored in registers 200 to 204

--- a/examples/Server Examples/modbus_server_example.yaml
+++ b/examples/Server Examples/modbus_server_example.yaml
@@ -79,7 +79,7 @@ Routines:
   values: [0.0, 0.3]
  Server:
   type: ModbusServer
-  address: 127.0.0.1  # this is the default localhost IP address, but can be set to any IP address assigned by a network to the host computer (clients must be on the same network)
+  address: 127.0.0.1  # this is the default localhost IP address, but can be set to any valid IP address of the host computer (clients must be on the same network)
   port: 6174  # the default port for modbus communication is 502, but any other valid port can be used
   knobs:
   # variables can be specified by a list


### PR DESCRIPTION
Previously, modbus registers in a ModbusServer routine were assigned as consecutive sets of 5, in the order of the given lists of knobs and meters. Now, these register addresses can be assigned by the user to give more flexibility in the layout of the registers.